### PR TITLE
Feature/web extjs

### DIFF
--- a/eva-web/src/js/eva-config.js
+++ b/eva-web/src/js/eva-config.js
@@ -371,6 +371,8 @@ var AVAILABLE_SPECIES = {
             "text": "Plants",
             "items": [
                 {"text": "Solanum lycopersicum", "assembly": "SL2.40"},
+                {"text": "Zea Mays", "assembly": "AGPv3"},
+                {"text": "Shorgum bicolor", "assembly": "Sorbi1"},
             ]
         }
     ]

--- a/eva-web/src/js/variant-widget/eva-variant-population-stats-panel.js
+++ b/eva-web/src/js/variant-widget/eva-variant-population-stats-panel.js
@@ -93,7 +93,8 @@ EvaVariantPopulationStatsPanel.prototype = {
 
         var panels = [];
 
-        var availableStudies = ['301','8616'];
+//        var availableStudies = ['301','8616'];
+        var availableStudies = ['301','8616', 'PRJEB6930','PRJEB4019'];
 
         for (var key in data) {
             console.log(data)

--- a/eva-web/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/eva-web/src/js/variant-widget/eva-variant-widget-panel.js
@@ -221,6 +221,8 @@ EvaVariantWidgetPanel.prototype = {
                 _this.variantWidget.toolTabPanel.getComponent(4).tab.show()
             }
 
+            _this.variantWidget.toolTabPanel.setActiveTab(0);
+
 //            if(e.species =='hsapiens_grch37' || e.species =='hsapiens_grch38'){
 //                _this.variantWidget.variantBrowserGrid.grid.getView().getHeaderAtIndex(2).setText('dbSNP ID')
 //                _this.formPanelVariantFilter.filters[1].panel.getForm().findField("snp").setFieldLabel('dbSNP accession')

--- a/eva-web/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/eva-web/src/js/variant-widget/eva-variant-widget-panel.js
@@ -210,10 +210,10 @@ EvaVariantWidgetPanel.prototype = {
             var plantSpecies = ['slycopersicum_sl240','zmays_b73refgenv3','zmays_agpv3'];
 
             //hidding tabs for species
-            if(e.species =='zmays_agpv3' ||  e.species == 'olatipes_hdrr'){
+            if(e.species =='zmays_agpv3'){
                 _this.variantWidget.toolTabPanel.getComponent(2).tab.hide()
                 _this.variantWidget.toolTabPanel.getComponent(4).tab.show()
-            }else if(e.species =='chircus_10'){
+            }else if(e.species =='chircus_10' ||  e.species == 'olatipes_hdrr'){
                 _this.variantWidget.toolTabPanel.getComponent(4).tab.hide()
                 _this.variantWidget.toolTabPanel.getComponent(2).tab.show()
             }else{

--- a/eva-web/src/js/variant-widget/eva-variant-widget.js
+++ b/eva-web/src/js/variant-widget/eva-variant-widget.js
@@ -1208,7 +1208,7 @@ EvaVariantWidget.prototype = {
         genomeViewer.addTrack([sequence, gene, snp]);
         this.on("species:change", function (e) {
             //disbaling for goat
-            if(e.values.species =='chircus_10'){
+            if(e.values.species =='chircus_10' || e.values.species =='olatipes_hdrr'){
                 return;
             }
             _this.taxonomy = e.values.species.split('_')[0];


### PR DESCRIPTION
fixes:

* medaka: hide genome viewer and show stats
* added maize and shorgum to available species for genome viewer
* using ENA ids to specify to show population stats just for 1000g phase 1 and 3
* moving to the first tab when changing species (there was a bug if a species with no genome viewer was selected while the genome viewer tab was open)
