### PR TITLE
Convert PRJEB/ERZ IDs also when returning VariantSource objects

### DIFF
--- a/eva-lib/src/main/java/uk/ac/ebi/variation/eva/lib/storage/metadata/VariantSourceEvaproDBAdaptor.java
+++ b/eva-lib/src/main/java/uk/ac/ebi/variation/eva/lib/storage/metadata/VariantSourceEvaproDBAdaptor.java
@@ -131,7 +131,7 @@ public class VariantSourceEvaproDBAdaptor implements VariantSourceDBAdaptor {
         try {
             conn = ds.getConnection();
             pstmt = conn.prepareStatement(
-                    "select distinct f.ftp_file " +
+                    "select distinct bf.filename, f.ftp_file " +
                     "from browsable_file bf " + 
                     "left join file f on bf.file_id = f.file_id " +
                     "where bf.filename = ?"
@@ -142,9 +142,9 @@ public class VariantSourceEvaproDBAdaptor implements VariantSourceDBAdaptor {
             rs = pstmt.executeQuery();
             
             if (rs.next()) {
-                URL url = new URL("ftp:/" + rs.getString(1));
+                URL url = new URL("ftp:/" + rs.getString(2));
                 long end = System.currentTimeMillis();
-                qr = new QueryResult(null, ((Long) (end - start)).intValue(), 1, 1, null, null, Arrays.asList(url));
+                qr = new QueryResult(rs.getString(1), ((Long) (end - start)).intValue(), 1, 1, null, null, Arrays.asList(url));
             } else {
                 long end = System.currentTimeMillis();
                 qr = new QueryResult(null, ((Long) (end - start)).intValue(), 0, 0, null, null, new ArrayList<>());
@@ -193,7 +193,7 @@ public class VariantSourceEvaproDBAdaptor implements VariantSourceDBAdaptor {
         ResultSet rs = null;
         List<QueryResult> results = new ArrayList<>();
         String query = 
-                "select distinct f.ftp_file " +
+                "select distinct bf.filename, f.ftp_file " +
                 "from browsable_file bf " +
                 "left join file f on bf.file_id = f.file_id " +
                 "where " + EvaproUtils.getInClause("bf.filename", filenames);
@@ -207,7 +207,7 @@ public class VariantSourceEvaproDBAdaptor implements VariantSourceDBAdaptor {
             
             while (rs.next()) {
                 results.add(new QueryResult(rs.getString(1), ((Long) (System.currentTimeMillis() - start)).intValue(), 
-                        1, 1, null, null, Arrays.asList(new URL("ftp:/" + rs.getString(1)))));
+                        1, 1, null, null, Arrays.asList(new URL("ftp:/" + rs.getString(2)))));
             }
             
         } catch (SQLException | MalformedURLException ex) {

--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/EvaWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/EvaWSServer.java
@@ -153,6 +153,7 @@ public class EvaWSServer {
         dict.put("PRJEB7723","12569");
         dict.put("PRJEB9507","33687");
         dict.put("PRJEB629","34064");
+        dict.put("PRJX00001","34711");
 
         studyDict = new HashMap<>();
         studyDict.put("5509", "PRJEB8652");
@@ -459,15 +460,15 @@ public class EvaWSServer {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(object).build();
     }
 
-    protected List<QueryResult<Variant>> translateFileIds(List<QueryResult<Variant>> variantQueryResults) {
+    protected List<QueryResult<Variant>> translateVariantFileIds(List<QueryResult<Variant>> variantQueryResults) {
         for (QueryResult<Variant> variantQueryResult : variantQueryResults) {
-            translateFileIds(variantQueryResult);
+            translateVariantFileIds(variantQueryResult);
         }
 
         return variantQueryResults;
     }
 
-    protected QueryResult<Variant> translateFileIds(QueryResult<Variant> variantQueryResult) {
+    protected QueryResult<Variant> translateVariantFileIds(QueryResult<Variant> variantQueryResult) {
         boolean translateFileIds = true,
                 translateStudyIds = true;
         if (translateFileIds || translateStudyIds) {
@@ -500,6 +501,47 @@ public class EvaWSServer {
         }
     }
 
+    protected List<QueryResult<VariantSource>> translateVariantSourceFileIds(List<QueryResult<VariantSource>> queryResults) {
+        for (QueryResult<VariantSource> queryResult : queryResults) {
+            translateVariantSourceFileIds(queryResult);
+        }
+
+        return queryResults;
+    }
+
+    protected QueryResult<VariantSource> translateVariantSourceFileIds(QueryResult<VariantSource> variantQueryResult) {
+        boolean translateFileIds = true,
+                translateStudyIds = true;
+        if (translateFileIds || translateStudyIds) {
+            for (VariantSource variantSource : variantQueryResult.getResult()) {
+                translateSourceFileId(translateFileIds, variantSource);
+                translateSourceStudyId(translateStudyIds, variantSource);
+            }
+        }
+
+        return variantQueryResult;
+    }
+
+    private void translateSourceStudyId(boolean translateStudyIds, VariantSource variantSource) {
+        if (translateStudyIds) {
+            String translatedStudyId = studyDict.get(variantSource.getStudyId());
+            if (translatedStudyId != null) {
+                variantSource.setStudyId(translatedStudyId);
+            }
+        }
+    }
+
+    private void translateSourceFileId(boolean translateFileIds, VariantSource variantSource) {
+        if (translateFileIds) {
+            String translatedFileId = erzIdsDict.get(variantSource.getFileId());
+            if (translatedFileId != null) {
+                variantSource.setFileId(translatedFileId);
+            }
+        }
+    }
+
+    
+    
 //    private Response buildResponse(Response.ResponseBuilder responseBuilder) {
 //        return responseBuilder.header("Access-Control-Allow-Origin", "*")
 //                .header("Access-Control-Allow-Headers", "x-requested-with, content-type, accept")

--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/GeneWSServer.java
@@ -122,7 +122,7 @@ public class GeneWSServer extends EvaWSServer {
         
         queryOptions.put("sort", true);
 
-        return createOkResponse(translateFileIds(variantMongoDbAdaptor.getAllVariantsByGene(geneId, queryOptions)));
+        return createOkResponse(translateVariantFileIds(variantMongoDbAdaptor.getAllVariantsByGene(geneId, queryOptions)));
     }
     
 }

--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/RegionWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/RegionWSServer.java
@@ -139,10 +139,10 @@ public class RegionWSServer extends EvaWSServer {
                 if (!queryOptions.containsKey("id") && !queryOptions.containsKey("gene")) {
                     return createErrorResponse("Some positional filer is needed, like region, gene or id.");
                 } else {
-                    return createOkResponse(translateFileIds(variantMongoDbAdaptor.getAllVariants(queryOptions)));
+                    return createOkResponse(translateVariantFileIds(variantMongoDbAdaptor.getAllVariants(queryOptions)));
                 }
             } else {
-                return createOkResponse(translateFileIds(variantMongoDbAdaptor.getAllVariantsByRegionList(regions, queryOptions)));
+                return createOkResponse(translateVariantFileIds(variantMongoDbAdaptor.getAllVariantsByRegionList(regions, queryOptions)));
             }
         } else {
             return createErrorResponse("The total size of all regions provided can't exceed 1 million positions. "

--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/StudyWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/StudyWSServer.java
@@ -86,7 +86,7 @@ public class StudyWSServer extends EvaWSServer {
                 id.getString(DBObjectToVariantSourceConverter.STUDYID_FIELD), queryOptions);
         finalResult.setDbTime(finalResult.getDbTime() + idQueryResult.getDbTime());
 
-        return createOkResponse(finalResult);
+        return createOkResponse(translateVariantSourceFileIds(finalResult));
     }
 
     @GET
@@ -115,7 +115,7 @@ public class StudyWSServer extends EvaWSServer {
             id.getString(DBObjectToVariantSourceConverter.STUDYID_FIELD), queryOptions);
         finalResult.setDbTime(finalResult.getDbTime() + idQueryResult.getDbTime());
 
-        return createOkResponse(finalResult);
+        return createOkResponse(translateVariantSourceFileIds(finalResult));
     }
 
     @GET

--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/VariantWSServer.java
@@ -71,7 +71,7 @@ public class VariantWSServer extends EvaWSServer {
         }
         
         if (!variantId.contains(":")) { // Query by accession id
-            return createOkResponse(translateFileIds(variantMongoDbAdaptor.getVariantById(variantId, queryOptions)));
+            return createOkResponse(translateVariantFileIds(variantMongoDbAdaptor.getVariantById(variantId, queryOptions)));
         } else { // Query by chr:pos:ref:alt
             String parts[] = variantId.split(":", -1);
             if (parts.length < 3) {
@@ -84,7 +84,7 @@ public class VariantWSServer extends EvaWSServer {
                 queryOptions.put("alternate", parts[3]);
             }
 
-            return createOkResponse(translateFileIds(variantMongoDbAdaptor.getAllVariantsByRegion(region, queryOptions)));
+            return createOkResponse(translateVariantFileIds(variantMongoDbAdaptor.getAllVariantsByRegion(region, queryOptions)));
         }
     }
 
@@ -124,7 +124,7 @@ public class VariantWSServer extends EvaWSServer {
             QueryResult queryResult = variantMongoDbAdaptor.getAllVariantsByRegion(region, queryOptions);
             queryResult.setResult(Arrays.asList(queryResult.getNumResults() > 0));
             queryResult.setResultType(Boolean.class.getCanonicalName());
-            return createOkResponse(translateFileIds(queryResult));
+            return createOkResponse(translateVariantFileIds(queryResult));
         }
     }
 

--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/ga4gh/GA4GHVariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/ga4gh/GA4GHVariantWSServer.java
@@ -104,7 +104,7 @@ public class GA4GHVariantWSServer extends EvaWSServer {
             }
             return createOkResponse(variantMongoDbAdaptor.getVariantFrequencyByRegion(region, queryOptions));
         } else if (regionSize <= 1000000) {
-            QueryResult<Variant> qr = translateFileIds(variantMongoDbAdaptor.getAllVariantsByRegion(region, queryOptions));
+            QueryResult<Variant> qr = translateVariantFileIds(variantMongoDbAdaptor.getAllVariantsByRegion(region, queryOptions));
             // Convert Variant objects to GAVariant
             List<GAVariant> gaVariants = GAVariantFactory.create(qr.getResult());
             // Calculate the next page token


### PR DESCRIPTION
The conversion was properly done in the web services that return Variant objects, but not in those that return VariantSource objects.