### PR TITLE
Gene web service supporting interval MAF arguments

### DIFF
--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/GeneWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/GeneWSServer.java
@@ -55,16 +55,10 @@ public class GeneWSServer extends EvaWSServer {
 //    @ApiOperation(httpMethod = "GET", value = "Retrieves all the variants of a gene", response = QueryResponse.class)
     public Response getVariantsByGene(@PathParam("gene") String geneId,
                                       @QueryParam("ref") String reference,
-                                      @QueryParam("alt") String alternate, 
-                                      @QueryParam("effects") String effects,
-                                      @QueryParam("studies") String studies,
+                                      @QueryParam("alt") String alternate,
                                       @QueryParam("species") String species,
-                                      @DefaultValue("-1f") @QueryParam("maf") float maf,
-                                      @DefaultValue("-1") @QueryParam("miss_alleles") int missingAlleles,
-                                      @DefaultValue("-1") @QueryParam("miss_gts") int missingGenotypes,
-                                      @DefaultValue("=") @QueryParam("maf_op") String mafOperator,
-                                      @DefaultValue("=") @QueryParam("miss_alleles_op") String missingAllelesOperator,
-                                      @DefaultValue("=") @QueryParam("miss_gts_op") String missingGenotypesOperator,
+                                      @DefaultValue("") @QueryParam("miss_alleles") String missingAlleles,
+                                      @DefaultValue("") @QueryParam("miss_gts") String missingGenotypes,
                                       @DefaultValue("") @QueryParam("type") String variantType)
             throws IllegalOpenCGACredentialsException, UnknownHostException, IOException {
         try {
@@ -92,32 +86,8 @@ public class GeneWSServer extends EvaWSServer {
         if (alternate != null) {
             queryOptions.put("alternate", alternate);
         }
-        if (effects != null) {
-            queryOptions.put("effect", Arrays.asList(effects.split(",")));
-        }
-        if (studies != null) {
-            queryOptions.put("studies", Arrays.asList(studies.split(",")));
-        }
         if (!variantType.isEmpty()) {
             queryOptions.put("type", variantType);
-        }
-        if (maf >= 0) {
-            queryOptions.put("maf", maf);
-            if (mafOperator != null) {
-                queryOptions.put("opMaf", mafOperator);
-            }
-        }
-        if (missingAlleles >= 0) {
-            queryOptions.put("missingAlleles", missingAlleles);
-            if (missingAllelesOperator != null) {
-                queryOptions.put("opMissingAlleles", missingAllelesOperator);
-            }
-        }
-        if (missingGenotypes >= 0) {
-            queryOptions.put("missingGenotypes", missingGenotypes);
-            if (missingGenotypesOperator != null) {
-                queryOptions.put("opMissingGenotypes", missingGenotypesOperator);
-            }
         }
         
         queryOptions.put("sort", true);


### PR DESCRIPTION
Bugfix for the cases when the web service that retrieves the variants in a gene couldn't process an argument like `maf=>0.3`, but worked with `maf=0.3` (exact search) and without that argument at all.

The reason for this was that the old WS interface used both "maf" and "mafOp" as arguments, whereas the next versions of OpenCGA only required "maf", including the operator in that argument.