### PR TITLE
Fixed search of symbolic ALT IDs in variants/info web service

### DIFF
--- a/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/VariantWSServer.java
+++ b/eva-server/src/main/java/uk/ac/ebi/variation/eva/server/ws/VariantWSServer.java
@@ -81,7 +81,7 @@ public class VariantWSServer extends EvaWSServer {
             Region region = new Region(parts[0], Integer.parseInt(parts[1]), Integer.parseInt(parts[1]));
             queryOptions.put("reference", parts[2]);
             if (parts.length > 3) {
-                queryOptions.put("alternate", parts[3]);
+                queryOptions.put("alternate", String.join(":", Arrays.copyOfRange(parts, 3, parts.length)));
             }
 
             return createOkResponse(variantMongoDbAdaptor.getAllVariantsByRegion(region, queryOptions));


### PR DESCRIPTION
Requests with symbolic ALT IDs such as `7:83532609:T:<INS:ME:ALU>` were failing due to an incorrect handling of the colon separator, treated the same way in and out of the angle brackets.